### PR TITLE
"ident" removed from namedtuple

### DIFF
--- a/netapp_eseries/agents/special/agent_netappeseries
+++ b/netapp_eseries/agents/special/agent_netappeseries
@@ -370,7 +370,7 @@ def main(argv: Any = None) -> int:
     args = None
     Section = namedtuple(
         "Section",
-        ["name", "uri", "perfdata_uri", "perfdata_identifier", "ident"])
+        ["name", "uri", "perfdata_uri", "perfdata_identifier"])
     sections = [
         Section(
             name="batteries",


### PR DESCRIPTION
Nach Commit https://github.com/chexma/checkmk_plugins/commit/e1aa6e130a00ed291ca040b5e4cf0e21d8e0c0e9#diff-a659aafd614f52fddebe2fe23e59488c8795dcbb2352372aee7700269a6adb77
war noch im namedtuple der "ident" Eintrag vorhanden.