### PR TITLE
System-ID can also be a string or the WWN

### DIFF
--- a/netapp_eseries/agents/special/agent_netappeseries
+++ b/netapp_eseries/agents/special/agent_netappeseries
@@ -78,7 +78,6 @@ def parse_arguments(argv: List[str]) -> argparse.Namespace:
     parser.add_argument("-i",
                         "--system-id",
                         default=1,
-                        type=int,
                         help="""Your E-Series System ID""")
     parser.add_argument(
         "-p",

--- a/netapp_eseries/web/plugins/wato/netapp_eseries_datasource_programs.py
+++ b/netapp_eseries/web/plugins/wato/netapp_eseries_datasource_programs.py
@@ -96,12 +96,10 @@ def _valuespec_special_agents_netappeseries():
                     ('https', _("https")),
                 ],
             )),
-            ("system-id", Integer(
+            ("system-id", TextAscii(
                 title = _("Advanced - E-Series-System-ID"),
                 help = _("The System ID of your Netapp E-Series. Should always be 1 if not connected through a SANtricity Web Proxy"),
                 default_value = 1,
-                minvalue = 1,
-                maxvalue = 1024,
             )),
         ],
     )


### PR DESCRIPTION
Especially for connection thru Santricity proxy a string system id is needed.
