### PR TITLE
fix(netapp_special_agent): handle invalid JSON from unavailable perfd…

### DIFF
--- a/checkmk-2.3/netapp_eseries/plugins/netapp_eseries/special_agents/agent_netappeseries.py
+++ b/checkmk-2.3/netapp_eseries/plugins/netapp_eseries/special_agents/agent_netappeseries.py
@@ -155,9 +155,15 @@ def fetch_storage_data(session, sections, args, base_url, controller_ids):
 
             # fetch performance data of current section if available and add it to the items
             if section.perfdata_uri is not None:
-                section_perfdata = session.get(
-                    base_url + section.perfdata_uri, verify=args.verify_ssl
-                ).json()
+                try:
+                    section_perfdata = session.get(
+                        base_url + section.perfdata_uri, verify=args.verify_ssl
+                    ).json()
+                except requests.exceptions.JSONDecodeError as e:
+                    LOGGER.debug(
+                        f"Performance Data could not be handled: {e} - Sending empty section_perfdata."
+                    )
+                    section_perfdata = {}
 
                 # Section "System" is the only section that is not a list with multiple json/dict items, but json itself, so we 'list' it, to not break our looping
                 if section.name == "system":


### PR DESCRIPTION
…ata endpoint gracefully

Wrapped JSON decoding of performance data in a try/except block to avoid crashes when the NetApp Perfdata endpoint `(/analysed-controller-statistics)` is not available.

Previously, the code assumed valid JSON would always be returned, which led to a `JSONDecodeError` on systems where the endpoint returns a 404.

Now, in such cases, the code logs a debug message and proceeds with an empty `section_perfdata`.

Tested on a NetApp E-Series system where `/controller-statistics` works, but `/analysed-controller-statistics` is unavailable.